### PR TITLE
extend SolarCharger output

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -155,6 +155,10 @@ class SignalKScanner(Scanner):
                             "path": f"electrical.solar.{id_}.loadCurrent",
                             "value": data.get_external_device_load(),
                         },
+                        {
+                            "path": f"electrical.solar.{id_}.yieldToday",
+                            "value": data.get_yield_today(),
+                        },
                     ],
                 },
             ],

--- a/plugin.py
+++ b/plugin.py
@@ -147,6 +147,14 @@ class SignalKScanner(Scanner):
                             "path": f"electrical.solar.{id_}.chargingMode",
                             "value": data.get_charge_state().name.lower(),
                         },
+                        {
+                            "path": f"electrical.solar.{id_}.panelPower",
+                            "value": data.get_solar_power(),
+                        },
+                        {
+                            "path": f"electrical.solar.{id_}.loadCurrent",
+                            "value": data.get_external_device_load(),
+                        },
                     ],
                 },
             ],


### PR DESCRIPTION
although panelPower is non-spec (panelVoltage and panelCurrent are...), it's really helpful to see at a glance how well the panel is performing.

loadCurrent is in spec: https://signalk.org/specification/1.7.0/doc/vesselsBranch.html#vesselsregexpelectricalsolarregexploadcurrent 
and there's no reason not to populate the path if we have the data.

Fixes: #4