### PR TITLE
change solar yieldToday from Wh to Joule

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -203,7 +203,7 @@ class SignalKScanner(Scanner):
                         },
                         {
                             "path": f"electrical.solar.{id_}.yieldToday",
-                            "value": data.get_yield_today(),
+                            "value": data.get_yield_today() * 3600,
                         },
                     ],
                 },


### PR DESCRIPTION
as specified in https://github.com/SignalK/specification/blob/master/schemas/groups/electrical.json the yieldToday value should be in Joule, but the BLE data contains the daily energy yield in Watt-hours, not in Watt-seconds (aka Joule), so the value returned by the BLE code needs to be multiplied by 3600 before being pushed to SignalK.