### PR TITLE
Fix solar yield to report Joules rather than w/h

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -392,7 +392,7 @@ class SignalKScanner(Scanner):
             },
             {
                 "path": f"electrical.solar.{id_}.yieldToday",
-                "value": data.get_yield_today(),
+                "value": data.get_yield_today() * 3600, // SignalK expects Joules
             },
         ]
 


### PR DESCRIPTION
Fixed issue where the plugin was reporting w/h to the solar yield path in w/h while SignalK expected Joules.