### PR TITLE
Pinned victron_ble python package to working version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-victron_ble>=0.9.2
+victron_ble==0.9.2


### PR DESCRIPTION
The `victron_ble` package was just [updated ](https://github.com/keshavdv/victron-ble/releases/tag/v0.9.3) to `0.9.3`, which satisfies the version in `requirements.txt`. Unfortunately [this change](https://github.com/keshavdv/victron-ble/commit/f9f8475fe1383c77c60a60c9137a8b5407f8b975) is incompatible with some of the `scanner.py` calls used in this package.

When updating signalk, I assume the dependencies are resolved to the latest valid version, silently introducing a bump to `0.9.3`. This PR fixes this by pinning the version to exactly `0.9.2`. Tested for me locally through restarts.

The bug shows up like this in the signalk server/server logs page:
```
Nov 18 20:29:37 ERROR:dbus_fast.message_bus:A message handler raised an exception: SignalKScanner.callback() takes 3 positional arguments but 4 were given Traceback (most recent call last): File "src/dbus_fast/message_bus.py", line 819, in dbus_fast.message_bus.BaseMessageBus._process_message File "/home/pi/.signalk/node_modules/signalk-victron-ble/ve/lib/python3.11/site-packages/bleak/backends/bluezdbus/manager.py", line 1070, in _parse_msg self._run_advertisement_callbacks( File "/home/pi/.signalk/node_modules/signalk-victron-ble/ve/lib/python3.11/site-packages/bleak/backends/bluezdbus/manager.py", line 1113, in _run_advertisement_callbacks callback(device_path, device.copy()) File "/home/pi/.signalk/node_modules/signalk-victron-ble/ve/lib/python3.11/site-packages/bleak/backends/bluezdbus/scanner.py", line 233, in _handle_advertising_data self.call_detection_callbacks(device, advertisement_data) File "/home/pi/.signalk/node_modules/signalk-victron-ble/ve/lib/python3.11/site-packages/bleak/backends/scanner.py", line 239, in call_detection_callbacks callback(device, advertisement_data) File "/home/pi/.signalk/node_modules/signalk-victron-ble/ve/lib/python3.11/site-packages/victron_ble/scanner.py", line 39, in _detection_callback self.callback(device, data, advertisement) TypeError: SignalKScanner.callback() takes 3 positional arguments but 4 were given
```