### PR TITLE
Don't leak scanner processes and supervisor loops across restarts

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const pkgData = require('./package.json')
 
 module.exports = function (app) {
   let child
+  let generation = 0
   function sleep(ms) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -13,9 +14,10 @@ module.exports = function (app) {
   }
   function run_python_plugin(options) {
       let args = ['plugin.py']
-      child = spawn('ve/bin/python', args, { cwd: __dirname })
+      const proc = spawn('ve/bin/python', args, { cwd: __dirname })
+      child = proc
 
-      child.stdout.on('data', data => {
+      proc.stdout.on('data', data => {
         app.debug(data.toString())
         try {
           data.toString().split(/\r?\n/).forEach(line => {
@@ -29,27 +31,36 @@ module.exports = function (app) {
         }
       })
 
-      child.stderr.on('data', fromChild => {
+      proc.stderr.on('data', fromChild => {
         console.error(fromChild.toString())
       })
 
-      child.on('error', err => {
+      proc.on('error', err => {
         console.error(err)
       })
 
-      child.on('close', code => {
+      proc.on('close', code => {
         if (code !== 0) {
           console.warn(`Plugin exited ${code}, restarting...`)
         }
-        child = undefined
+        // A close event from an earlier process must not clear the handle to
+        // the current one, or the loop below would spawn a second scanner.
+        if (child === proc) {
+          child = undefined
+        }
       })
 
-      child.stdin.write(JSON.stringify(options))
-      child.stdin.write('\n')
+      proc.stdin.write(JSON.stringify(options))
+      proc.stdin.write('\n')
   };
   return {
     start: async (options) => {
-      while (true) {
+      // The server restarts a plugin by calling stop() and start() back to
+      // back, and stop() is synchronous, so start() runs before any sleeping
+      // loop can wake up. A boolean flag would already be back to true by
+      // then; the generation counter makes every earlier loop exit instead.
+      const myGeneration = ++generation
+      while (myGeneration === generation) {
         if (child === undefined) {
           run_python_plugin(options);
         }
@@ -57,8 +68,9 @@ module.exports = function (app) {
       }
     },
     stop: () => {
+      generation++
       if (child) {
-        process.kill(child.pid)
+        child.kill()
         child = undefined
       }
     },


### PR DESCRIPTION
Several `plugin.py` processes end up running side by side, all scanning the same adapter. They accumulate one per plugin restart, and the server restarts a plugin every time its config is saved. Two distinct bugs.

**A stale `close` event clears the handle to the current process.** The handler cleared the shared `child` variable unconditionally, so a close event arriving from an already-killed process discards the handle to its *replacement*; the loop then sees `child === undefined` and spawns a duplicate while the previous scanner is still alive. Capture the process in a local `const` and only clear `child` when it still refers to that process.

**Supervisor loops are never retired.** `start()` looped on `while (true)` with nothing to end it, so every restart left another loop polling forever. A boolean flag does not fix this: the server restarts a plugin as `stopPlugin(plugin).then(() => doPluginStart(...))`, and `plugin.stop()` is synchronous, so `start()` runs as a microtask before any timer can fire and sets the flag back to true before a sleeping loop observes the false. Give each `start()` a generation number and let the loop run only while it owns the current one.

That second one is not merely untidy. Each loop closes over the `options` it was started with, so when the scanner dies the loop that happens to wake first respawns it with *its* config. Sweeping the phase of the crash across one second, after five config saves, the original respawned with config v2, v2, v4, v4 and v3 -- never the current v5. For a user that reads as a device added or an advertisement key changed in the UI that silently keeps using stale settings until the server is restarted.

Also use `child.kill()` instead of `process.kill(child.pid)`. Between a child's `exit` and `close` events the process is already reaped while `child` is still set, and `process.kill` throws ESRCH there -- out of `stop()`, past the un-guarded `Promise.resolve(plugin.stop())` in the server, so the following `doPluginStart` never runs and the plugin stays down. `child.kill()` is a no-op after exit and cannot hit a recycled pid.

Verified with a harness that drives start/stop the way the server does and counts both live processes and live loops. Before: 1, 2, 3, 4, 5 of each after successive config saves, and five loops still polling after `stop()`. After: 1 and 1 throughout, 0 and 0 after `stop()`. Note the original `stop()` does not stop the plugin at all -- it kills one process and a surviving loop respawns it a second later.


Claude-Session: https://claude.ai/code/session_014355grTWdGQEJ37K9WUw95